### PR TITLE
Bumped Node Version to 10.x.

### DIFF
--- a/amplify/backend/auth/rnconfinabox58de14db/rnconfinabox58de14db-cloudformation-template.yml
+++ b/amplify/backend/auth/rnconfinabox58de14db/rnconfinabox58de14db-cloudformation-template.yml
@@ -247,7 +247,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole


### PR DESCRIPTION
AWS Lambda deprecated its runtime support for Node.js 8.10.  Fixes #12 