### PR TITLE
Bumped Node Version to 10.x. AWS Lambda deprecated its runtime suppor…

### DIFF
--- a/amplify/backend/auth/rnconfinabox58de14db/rnconfinabox58de14db-cloudformation-template.yml
+++ b/amplify/backend/auth/rnconfinabox58de14db/rnconfinabox58de14db-cloudformation-template.yml
@@ -247,7 +247,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole


### PR DESCRIPTION
…t for Node.js 6.10 on April 30th, 2019[ref], and it has started to support Node.js 8.10. 